### PR TITLE
Fix cluster version fetch for single cluster

### DIFF
--- a/src/v2/models/cluster.js
+++ b/src/v2/models/cluster.js
@@ -134,7 +134,7 @@ export default class ClusterModel extends KubeModel {
     const [clusters, clusterstatuses, ...clusterversions] = await Promise.all([
       this.kubeConnector.get(`/apis/clusterregistry.k8s.io/v1alpha1/namespaces/${namespace}/clusters/${name}`),
       this.kubeConnector.get(`/apis/mcm.ibm.com/v1alpha1/namespaces/${namespace}/clusterstatuses/${name}`),
-      this.kubeConnector.resourceViewQuery('clusterversions', name, 'version', null, 'config.openshift.io'),
+      this.kubeConnector.resourceViewQuery('clusterversions', name, 'version', null, 'config.openshift.io').catch(() => null),
     ]);
     const results = findMatchedStatus([clusters], [clusterstatuses], clusterversions);
     return results;


### PR DESCRIPTION
Missed case for single cluster.
For single cluster, queries are all done in parallel to save time, so we always attempt to fetch ClusterVersion, but missing or error will be handled gracefully.