### PR TITLE
Exclude mocks directory and fix two sonar bugs

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=open-cluster-management_console-api
 sonar.projectName=console-api
 sonar.sources=src
-sonar.exclusions=test-output/**/*,node_modules/**/*,src/**/*.test.js
+sonar.exclusions=test-output/**/*,node_modules/**/*,src/**/*.test.js,src/v2/mocks/**/*
 sonar.tests=src
 sonar.test.inclusions=src/**/*.test.js
 sonar.javascript.lcov.reportPaths=test-output/coverage/lcov.info

--- a/src/v2/mocks/iam-http.js
+++ b/src/v2/mocks/iam-http.js
@@ -36,13 +36,8 @@ export default function createMockHttp() {
     },
   };
 
-  return async function MockLib(params) {
-    switch (true) {
-      case params.url.includes('resourceType=namespace'):
-        return state.namespaces;
-      default:
-        return state.namespaces;
-    }
+  return async function MockLib() {
+    return state.namespaces;
   };
 }
 

--- a/src/v2/models/compliance.js
+++ b/src/v2/models/compliance.js
@@ -78,8 +78,6 @@ export default class ComplianceModel {
   }
 
   async getCompliances(name, namespace) {
-    let compliancesAndPolicies = [];
-    const compliances = [];
     let policies = [];
 
     if (!name) {
@@ -98,8 +96,7 @@ export default class ComplianceModel {
         policies.push(policyResponse);
       }
     }
-    compliancesAndPolicies = compliances.concat(policies);
-    return compliancesAndPolicies.map(entry => ({
+    return policies.map(entry => ({
       ...entry,
       raw: entry,
       name: _.get(entry, 'metadata.name', ''),


### PR DESCRIPTION
Bugs:

https://sonarcloud.io/project/issues?id=open-cluster-management_console-api&resolved=false&types=BUG

Duplications were mostly because of the `mocks` directory:

https://sonarcloud.io/component_measures?id=open-cluster-management_console-api&metric=duplicated_lines_density&view=list