### PR TITLE
Push a "latest" image on master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
         - make component/build
         - make component/push
         - if [ "$IMAGE_SCAN" != "false" ]; then make security/scans; fi;
-        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then 
+        - if [ "$TRAVIS_BRANCH" == "master" ]; then 
             export COMPONENT_NEWTAG="latest";
             make component/tag;
             export COMPONENT_VERSION="latest";


### PR DESCRIPTION
I need a `latest` image for console-api in order to make the console-ui tests work.  I have copied this code from `grc-ui-api`:  https://github.com/open-cluster-management/grc-ui-api/blob/master/.travis.yml#L54
