### PR TITLE
remove topology calls to ResourceViewer

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -1,7 +1,7 @@
 /** *****************************************************************************
  * Licensed Materials - Property of IBM
  * (c) Copyright IBM Corporation 2019. All Rights Reserved.
- *
+ * Copyright (c) 2020 Red Hat, Inc.
  * Note to U.S. Government Users Restricted Rights:
  * Use, duplication or disclosure restricted by GSA ADP Schedule
  * Contract with IBM Corp.
@@ -96,31 +96,13 @@ function addSubscriptionDeployable(
   // deployable shape
   const { name, namespace } = _.get(deployable, 'metadata');
   const deployableId = `member--deployable--${parentId}--${namespace}--${name}`;
-  nodes.push({
-    name,
-    namespace,
-    type: 'deployable',
-    id: deployableId,
-    uid: deployableId,
-    specs: { isDesign: true, raw: deployable, isDivider: true },
-  });
-  links.push({
-    from: { uid: parentId },
-    to: { uid: deployableId },
-    type: '',
-    specs: { isDesign: true },
-  });
 
   // installs these K8 objects
-  let failed = false;
   const deployStatuses = [];
   names.forEach((cname) => {
     const status = _.get(subscriptionStatusMap, `${cname}.${name}`);
     if (status) {
       deployStatuses.push(status);
-      if (status.phase === 'Failed') {
-        failed = true;
-      }
     }
   });
 
@@ -139,28 +121,10 @@ function addSubscriptionDeployable(
     specs: { raw: template, deployStatuses, isDesign: kind === 'deployable' || kind === 'subscription' },
   });
   links.push({
-    from: { uid: deployableId },
+    from: { uid: parentId },
     to: { uid: memberId },
     type: '',
   });
-
-  // if deployment, show pod--unless deployable failed to deploy deployment
-  if (kind === 'deployment' && !failed) {
-    const podId = `member--pod--${deployableId}--${k8Name}`;
-    nodes.push({
-      name: k8Name,
-      namespace: '',
-      type: 'pod',
-      id: podId,
-      uid: podId,
-      specs: { raw: template },
-    });
-    links.push({
-      from: { uid: memberId },
-      to: { uid: podId },
-      type: '',
-    });
-  }
 }
 
 function addSubscriptionCharts(parentId, subscriptionStatusMap, nodes, links) {

--- a/src/v2/schema/query.js
+++ b/src/v2/schema/query.js
@@ -92,7 +92,6 @@ type Query {
 
   # Gets data for the topology diagram.
   topology(filter: TopologyFilter): Topology
-  topologyDetails(filter: TopologyDetailsFilter): TopologyDetails
 
   getAutomatedImportStatus(namespace: String, name: String): JSON
 

--- a/src/v2/schema/topology.js
+++ b/src/v2/schema/topology.js
@@ -8,7 +8,6 @@
  * Contract with IBM Corp.
  ****************************************************************************** */
 
-import _ from 'lodash';
 import getApplicationElements from './applicationHelper';
 
 export const typeDef = `
@@ -56,13 +55,6 @@ input TopologyFilter {
   type: [String]
 }
 
-type TopologyDetails {
-  pods: [JSON]
-}
-
-input TopologyDetailsFilter {
-  clusterNames: [String]
-}
 `;
 
 export const resolver = {
@@ -79,36 +71,6 @@ export const resolver = {
       }
       return { resources, relationships };
     },
-
-    // second pass--get topology details
-    topologyDetails: async (root, args, { resourceViewModel }) => {
-      let pods = await resourceViewModel.fetchResources({ type: 'pods' }, _.get(args, 'filter.clusterNames'));
-      pods = pods.map((pod) => {
-        const {
-          metadata, cluster, containers: cntrs, status, hostIP, podIP, restarts, startedAt,
-        } = pod;
-        const {
-          name, namespace, creationTimestamp, labels,
-        } = metadata;
-        const containers = cntrs.map(({ name: n, image }) => ({
-          name: n,
-          image,
-        }));
-        return {
-          name,
-          namespace,
-          status,
-          cluster,
-          containers,
-          creationTimestamp,
-          labels,
-          hostIP,
-          podIP,
-          restarts,
-          startedAt,
-        };
-      });
-      return { pods };
-    },
   },
+
 };


### PR DESCRIPTION
https://app.zenhub.com/workspaces/engineering-5e480a1f17e47394a67447b9/issues/open-cluster-management/backlog/2053

With this change we remove pods queries ; I also removed deployable objects from the topo
Pods information will be retrieved using search

<img width="942" alt="Screen Shot 2020-05-07 at 6 16 08 PM" src="https://user-images.githubusercontent.com/43010150/81349936-ff3a7b80-908e-11ea-99ae-805605f679bc.png">
