### PR TITLE
parse chart info to retrieve deployables

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -127,30 +127,71 @@ function addSubscriptionDeployable(
   });
 }
 
-function addSubscriptionCharts(parentId, subscriptionStatusMap, nodes, links, appNamespace) {
-  Object.values(subscriptionStatusMap).forEach((value) => {
-    if (value) {
-      const [packageName] = Object.keys(value);
-      const memberId = `member--package--${packageName}`;
-      const status = value[packageName];
-      const deployStatuses = [];
-      if (status) {
-        deployStatuses.push(status);
-      }
-      nodes.push({
-        name: packageName,
-        namespace: appNamespace,
-        type: 'package',
-        id: memberId,
-        uid: memberId,
-        specs: { raw: value, deployStatuses, isDesign: false },
-      });
-      links.push({
-        from: { uid: parentId },
-        to: { uid: memberId },
-        type: '',
-      });
+function addSubscriptionCharts(
+  parentId, subscriptionStatusMap,
+  nodes, links, appNamespace, channelInfo,
+) {
+  let channelName = null;
+  if (channelInfo) {
+    const splitIndex = _.indexOf(channelInfo, '/');
+    if (splitIndex !== -1) {
+      channelName = channelInfo.substring(splitIndex + 1);
     }
+  }
+  const packagedObjects = {};
+
+  if (!channelName) {
+    return; // could not find the subscription channel name, abort
+  }
+
+  Object.values(subscriptionStatusMap).forEach((packageItem) => {
+    Object.keys(packageItem).forEach((packageItemKey) => {
+      if (packageItemKey.startsWith(channelName)) {
+        const objectInfo = packageItemKey.substring(channelName.length + 1);
+        let objectType;
+        let objectName;
+        // now find the type-name
+        const splitIndex = _.indexOf(objectInfo, '-');
+        if (splitIndex !== -1) {
+          objectName = objectInfo.substring(splitIndex + 1);
+          objectType = objectInfo.substring(0, splitIndex);
+
+          const keyStr = `${objectName}-${objectType}`;
+
+          if (!packagedObjects[keyStr]) {
+            const objId = `member--deployable--${parentId}--${objectType.toLowerCase()}--${objectName}`;
+
+            const chartObject = {
+              id: objId,
+              uid: objId,
+              name: objectName,
+              namespace: appNamespace,
+              type: objectType.toLowerCase(),
+              specs: {
+                isDesign: true,
+                raw: {
+                  kind: objectType,
+                  metadata: {
+                    name: objectName,
+                    namespace: appNamespace,
+                  },
+                  spec: _.get(packageItem[packageItemKey], 'resourceStatus'),
+                },
+              },
+
+            };
+
+            nodes.push(chartObject);
+            links.push({
+              from: { uid: parentId },
+              to: { uid: objId },
+              type: 'package',
+            });
+            packagedObjects[keyStr] = chartObject;
+          }
+        }
+      }
+    });
   });
 }
 
@@ -198,6 +239,7 @@ async function getApplicationElements(application, clusterModel) {
   if (application.subscriptions) {
     const createdClusterElements = new Set();
     application.subscriptions.forEach((subscription) => {
+      const subscriptionChannel = _.get(subscription, 'spec.channel');
       // get cluster placement if any
       const ruleDecisionMap = {};
       if (subscription.rules) {
@@ -257,14 +299,20 @@ async function getApplicationElements(application, clusterModel) {
             });
           } else if (isSubscriptionPlaced) {
           // else add charts which does deployment
-            addSubscriptionCharts(clusterId, subscriptionStatusMap, nodes, links, namespace);
+            addSubscriptionCharts(
+              clusterId, subscriptionStatusMap, nodes
+              , links, namespace, subscriptionChannel,
+            );
           }
         });
       }
 
       // no deployables was placed on a clutser but there were subscription decisions
       if (!subscription.deployables && !hasPlacementRules && subscribeDecisions) {
-        addSubscriptionCharts(parentId, subscriptionStatusMap, nodes, links, namespace);
+        addSubscriptionCharts(
+          parentId, subscriptionStatusMap, nodes
+          , links, namespace, subscriptionChannel,
+        );
       }
       delete subscription.deployables;
     });


### PR DESCRIPTION
https://app.zenhub.com/workspaces/applifecycle-issue-tracker-5e480a1f17e47394a67447b9/issues/open-cluster-management/backlog/434

Parse subscription packages and create deployment info based on that

<img width="872" alt="Screen Shot 2020-05-25 at 3 43 57 PM" src="https://user-images.githubusercontent.com/43010150/82840452-acd7c800-9ea0-11ea-8aa1-3fa1c8e43de6.png">
