### PR TITLE
Server shutdown support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ server.listen(GRAPHQL_PORT, () => {
 });
 
 function shutdown() {
-  if (server) {
+  if (server !== null) {
     /* istanbul ignore next */
     if (process.env.NODE_ENV === 'development') {
       setTimeout(() => {
@@ -62,7 +62,7 @@ function shutdown() {
     }
 
     server.close();
-    server = undefined;
+    server = null;
   }
 }
 


### PR DESCRIPTION
When the container gets a SIGTERM or SIGINT it should close the server.
server.close() will cause the server to stop accepting new requests.
It will then wait until open requests have completed and then stop.
Once everything is stopped, node will exit gracefully.