### PR TITLE
Set isDesign to false for child nodes under the cluster node

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -133,7 +133,7 @@ export const createReplicaChild = (parentObject, template, links, nodes) => {
     id: memberId,
     uid: memberId,
     specs: {
-      isDesign: true,
+      isDesign: false,
       raw: rawData,
       parent: {
         parentId,
@@ -194,7 +194,7 @@ export const addSubscriptionDeployable = (
     specs: {
       raw: template,
       deployStatuses,
-      isDesign: kind === 'deployable' || kind === 'subscription',
+      isDesign: false,
       parent: parentObject,
     },
   };

--- a/src/v2/schema/applicationHelper.test.js
+++ b/src/v2/schema/applicationHelper.test.js
@@ -56,7 +56,7 @@ describe('createReplicaChild', () => {
       type: 'deployment',
       specs:
       {
-        isDesign: true,
+        isDesign: false,
         raw: {
           kind: 'Deployment',
           metadata: {
@@ -84,7 +84,7 @@ describe('createReplicaChild', () => {
       name: 'redis-slave',
       namespace: 'open-cluster-management',
       specs: {
-        isDesign: true,
+        isDesign: false,
         parent: {
           parentId: 'member--deployable--member--clusters--possiblereptile, braveman, sharingpenguin, relievedox--deployment--redis-slave',
           parentName: 'redis-slave',


### PR DESCRIPTION
**Related Issue:** [closes|resolves|fixes] open-cluster-management/backlog#<ISSUE_NUMBER>

This change is made to support fixes for these issues:
open-cluster-management/backlog#2644

In particular this scenario where there are design nodes under the cluster node:
https://multicloud-console.apps.definite-oarfish.dev06.red-chesterfield.com/multicloud/applications/pbc-ns/playback-mortgage-rc

if isDesign is true then filtering will not work properly.

**Description of Changes**
Changed the logic to set isDesign false for all child nodes under the cluster node.

- [x] I wrote test cases to cover new code
