### PR TITLE
Change kubernetes nodes from charts to have isDesign false

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -387,7 +387,7 @@ export const addSubscriptionCharts = (
                 namespace: appNamespace,
                 type: objectType.toLowerCase(),
                 specs: {
-                  isDesign: true,
+                  isDesign: false,
                   raw: {
                     kind: objectType,
                     metadata: {

--- a/src/v2/schema/applicationHelper.test.js
+++ b/src/v2/schema/applicationHelper.test.js
@@ -812,7 +812,7 @@ describe('addSubscriptionCharts', () => {
         name: 'frontend',
         namespace: 'open-cluster-management',
         specs: {
-          isDesign: true,
+          isDesign: false,
           raw: {
             kind: 'Deployment',
             metadata: {
@@ -837,7 +837,7 @@ describe('addSubscriptionCharts', () => {
         name: 'redis-master',
         namespace: 'open-cluster-management',
         specs: {
-          isDesign: true,
+          isDesign: false,
           raw: {
             kind: 'Deployment',
             metadata: {
@@ -862,7 +862,7 @@ describe('addSubscriptionCharts', () => {
         name: 'redis-slave',
         namespace: 'open-cluster-management',
         specs: {
-          isDesign: true,
+          isDesign: false,
           raw: {
             kind: 'Deployment',
             metadata: {
@@ -887,7 +887,7 @@ describe('addSubscriptionCharts', () => {
         name: 'frontend',
         namespace: 'open-cluster-management',
         specs: {
-          isDesign: true,
+          isDesign: false,
           raw: {
             kind: 'Service',
             metadata: {
@@ -912,7 +912,7 @@ describe('addSubscriptionCharts', () => {
         name: 'redis-master',
         namespace: 'open-cluster-management',
         specs: {
-          isDesign: true,
+          isDesign: false,
           raw: {
             kind: 'Service',
             metadata: {
@@ -937,7 +937,7 @@ describe('addSubscriptionCharts', () => {
         name: 'redis-slave',
         namespace: 'open-cluster-management',
         specs: {
-          isDesign: true,
+          isDesign: false,
           raw: {
             kind: 'Service',
             metadata: {


### PR DESCRIPTION
**Related Issue:** [closes|resolves|fixes] open-cluster-management/backlog#<ISSUE_NUMBER>
https://github.com/open-cluster-management/backlog/issues/2795

**Description of Changes**
For kubernetes nodes parsed from charts, set the isDesign property to false.

- [x] I wrote test cases to cover new code
