### PR TITLE
process deployables first then helmchart objects

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -213,7 +213,8 @@ export const addSubscriptionDeployable = (
   return topoObject;
 };
 
-export const processRouteIngress = (
+// Route, Ingress, StatefulSet
+export const processServiceOwner = (
   clusterId, routes, links, nodes,
   subscriptionStatusMap, names, namespace,
 ) => {
@@ -247,7 +248,9 @@ export const processRouteIngress = (
       });
     } else if (kind === 'StatefulSet') {
       const service = _.get(deployable, 'spec.template.spec.serviceName');
-      if (service) servicesMap[service] = topoObject.id;
+      if (service) {
+        servicesMap[service] = topoObject.id;
+      }
     }
   });
   // return a map of services that must be linked to these router
@@ -282,7 +285,7 @@ export const processDeployables = (
   });
 
   // process route and ingress first
-  const serviceMap = processRouteIngress(
+  const serviceMap = processServiceOwner(
     clusterId, routes, links, nodes,
     subscriptionStatusMap, names, namespace,
   );

--- a/src/v2/schema/applicationHelper.test.js
+++ b/src/v2/schema/applicationHelper.test.js
@@ -15,7 +15,7 @@ import getApplicationElements, {
   addSubscriptionCharts,
   addSubscriptionDeployable,
   addClusters,
-  processRouteIngress,
+  processServiceOwner,
   processServices,
   processDeployables,
   getSubscriptionPackageInfo,
@@ -338,8 +338,8 @@ describe('addSubscriptionDeployable with parent node', () => {
   });
 });
 
-describe('processRouteIngress for Route', () => {
-  it('processRouteIngress for Route', () => {
+describe('processServiceOwner for Route', () => {
+  it('processServiceOwner for Route', () => {
     const parentId = 'member--clusters--braveman';
     const appNamespace = 'default';
     const subscriptionStatusMap = {
@@ -405,15 +405,88 @@ describe('processRouteIngress for Route', () => {
 
     const result = { service1: 'member--member--deployable--member--clusters--braveman--default--mortgagedc-subscription-mortgagedc-mortgagedc-deploy-route--route--undefined' };
 
-    expect(processRouteIngress(
+    expect(processServiceOwner(
       parentId, deployables, [], [],
       subscriptionStatusMap, names, appNamespace,
     )).toEqual(result);
   });
 });
 
-describe('processRouteIngress for Ingress', () => {
-  it('processRouteIngress for Ingress', () => {
+describe('processServiceOwner for StatefulSet', () => {
+  it('processServiceOwner for StatefulSet', () => {
+    const parentId = 'member--clusters--braveman';
+    const appNamespace = 'default';
+    const subscriptionStatusMap = {
+      braveman:
+      {
+        'mortgagedc-channel-Service-mortgagedc-svc':
+         {
+           lastUpdateTime: '2020-05-31T06:29:54Z',
+           phase: 'Failed',
+           reason: 'Service "mortgagedc-svc" is invalid: spec.clusterIP: Invalid value: "": field is immutable',
+           resourceStatus: {},
+         },
+      },
+    };
+    const names = ['braveman'];
+
+    const deployables = [{
+      apiVersion: 'apps.open-cluster-management.io/v1',
+      kind: 'Deployable',
+      metadata:
+      {
+        name: 'mortgagedc-subscription-mortgagedc-mortgagedc-deploy-route',
+        namespace: 'default',
+        uid: '4ba0370e-4013-41ff-975a-63f87f0ed7ff',
+      },
+      spec:
+      {
+        template:
+          {
+            apiVersion: 'apps.openshift.io/v1',
+            kind: 'StatefulSet',
+            spec: {
+              serviceName: 'aaa',
+            },
+            metadata: {},
+          },
+      },
+    },
+    {
+      apiVersion: 'apps.open-cluster-management.io/v1',
+      kind: 'Deployable',
+      metadata:
+      {
+        name: 'mortgagedc-subscription-mortgagedc-mortgagedc-deploy-route2',
+        namespace: 'default',
+        uid: '4ba0370e-4013-41ff-975a-63f87f0ed7ff',
+      },
+      spec:
+      {
+        template:
+          {
+            apiVersion: 'apps.openshift.io/v1',
+            kind: 'StatefulSet',
+            metadata: {},
+            spec: {
+            },
+          },
+      },
+    },
+    ];
+
+    const result = {
+      aaa: 'member--member--deployable--member--clusters--braveman--default--mortgagedc-subscription-mortgagedc-mortgagedc-deploy-route--statefulset--undefined',
+    };
+    expect(processServiceOwner(
+      parentId, deployables, [], [],
+      subscriptionStatusMap, names, appNamespace,
+    )).toEqual(result);
+  });
+});
+
+describe('processServiceOwner for Ingress', () => {
+  it('processServiceOwner for Ingress', () => {
     const parentId = 'member--clusters--braveman';
     const appNamespace = 'default';
     const subscriptionStatusMap = {
@@ -481,6 +554,38 @@ describe('processRouteIngress for Ingress', () => {
             metadata: {},
             spec: {
               rules: [
+                {
+                  http: {
+                    paths: [{
+                      backend: {
+                      },
+                    },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+      },
+    },
+    {
+      apiVersion: 'apps.open-cluster-management.io/v1',
+      kind: 'Deployable',
+      metadata:
+      {
+        name: 'mortgagedc-subscription-mortgagedc-mortgagedc-deploy-ingress2',
+        namespace: 'default',
+        uid: '4ba0370e-4013-41ff-975a-63f87f0ed7ff',
+      },
+      spec:
+      {
+        template:
+          {
+            apiVersion: 'apps.openshift.io/v1',
+            kind: 'Ingress',
+            metadata: {},
+            spec: {
+              rules: [
               ],
             },
           },
@@ -489,7 +594,7 @@ describe('processRouteIngress for Ingress', () => {
     ];
 
     const result = { service1: 'member--member--deployable--member--clusters--braveman--default--mortgagedc-subscription-mortgagedc-mortgagedc-deploy-ingress--ingress--undefined' };
-    expect(processRouteIngress(
+    expect(processServiceOwner(
       parentId, deployables, [], [],
       subscriptionStatusMap, names, appNamespace,
     )).toEqual(result);


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/3071

Process deployables first then helmchart objects; in this way, data available with the deployables ( such as serviceName, container info ) can be reused by the topo annotations

- [ X] I wrote test cases to cover new code
<img width="628" alt="Screen Shot 2020-06-26 at 9 43 14 AM" src="https://user-images.githubusercontent.com/43010150/85863706-894eb880-b791-11ea-8c63-7004f0e57dc0.png">
