### PR TITLE
Change "unknown" to "pending" for ClusterDeployment

### DIFF
--- a/RELEASE_FF_BRANCH
+++ b/RELEASE_FF_BRANCH
@@ -1,1 +1,1 @@
-release-2.1
+release-2.0

--- a/src/v2/models/cluster.js
+++ b/src/v2/models/cluster.js
@@ -40,7 +40,7 @@ function getCPUPercentage(usage, capacity) {
 function getClusterDeploymentStatus(clusterDeployment, uninstall, install) {
   const conditions = _.get(clusterDeployment, 'status.clusterVersionStatus.conditions');
   const conditionIndex = _.findIndex(conditions, (c) => c.type === 'Available');
-  let status = 'unknown';
+  let status = 'pending';
   if ((install && install.every((i) => i.status.failed > 0))
   || (uninstall && uninstall.every((i) => i.status.failed > 0))) {
     status = 'provisionfailed';


### PR DESCRIPTION
**Related Issue:** open-cluster-management/backlog#3309

**Description of Changes**
Changes the state before a cluster starts creating from "unknown" to "pending"
