### PR TITLE
Don't create the namespace if it already exists

### DIFF
--- a/src/v2/models/application.js
+++ b/src/v2/models/application.js
@@ -313,14 +313,9 @@ export default class ApplicationModel extends KubeModel {
 
     const existingNamespaces = await this.kubeConnector.get('/api/v1/namespaces');
     const namespaceResponses = await Promise.all(namespaces.map((ns) => {
-        const namespaceExists = existingNamespaces.items.find((existingNamespace) => {
-          return existingNamespace.metadata.name === ns;
-        });
-        if (!namespaceExists) {
-          return this.createNamespace(ns);
-        }
-      }
-    ));
+      const namespaceExists = existingNamespaces.items.find((existingNamespace) => existingNamespace.metadata.name === ns);
+      return !namespaceExists ? this.createNamespace(ns) : undefined;
+    }));
 
     namespaceResponses.forEach((item) => {
       if (item) {


### PR DESCRIPTION
**Related Issue:** [fixes] open-cluster-management/backlog#4534

**Description of Changes**

Prevent creation of namespace when the namespace already exists when users create an application.

The correct error shows up now:
<img width="1667" alt="image" src="https://user-images.githubusercontent.com/38960034/90445109-23095680-e0ad-11ea-8c51-a471284a17da.png">
