### PR TITLE
Update getSingleCluster to return empty when cluster requests return errors

### DIFF
--- a/src/v2/models/cluster.js
+++ b/src/v2/models/cluster.js
@@ -671,6 +671,11 @@ export default class ClusterModel extends KubeModel {
       listQuery(`/apis/batch/v1/namespaces/${name}/jobs?${UNINSTALL_LABEL_SELECTOR(name)}`),
       listQuery(`/apis/batch/v1/namespaces/${name}/jobs?${INSTALL_LABEL_SELECTOR(name)}`),
     ]);
+
+    if ((responseHasError(managedCluster) || responseHasError(managedClusterInfo)) && responseHasError(clusterDeployment)) {
+      return [];
+    }
+
     const [result] = findMatchedStatus({
       managedClusters: [managedCluster],
       clusterDeployments: [clusterDeployment],


### PR DESCRIPTION
Issue:  https://github.com/open-cluster-management/backlog/issues/1843

---

Response is returning a valid object and null pointer issues on the front-end