### PR TITLE
Add defensive coding for missing status field in MCA

### DIFF
--- a/src/v2/models/cluster.js
+++ b/src/v2/models/cluster.js
@@ -843,7 +843,7 @@ export default class ClusterModel extends KubeModel {
     }
 
     managedClusterAddons = managedClusterAddons.items.map((addon) => {
-      const { metadata, status: { conditions, relatedObjects, addOnMeta } } = addon;
+      const { metadata, status: { conditions = [], relatedObjects, addOnMeta } = {} } = addon;
       const crd = _.get(relatedObjects, '[0]', {});
 
       // Order of precedence:


### PR DESCRIPTION
Issue:  https://github.com/open-cluster-management/backlog/issues/6237

---

Fix working locally when configured to the QE environment from the issue:

![Screen Shot 2020-10-15 at 8 04 47 AM](https://user-images.githubusercontent.com/26075187/96120829-2490a880-0ebd-11eb-9913-1ba53919c244.png)

Culprit `ManagedClusterAddon` example:

```yaml
apiVersion: addon.open-cluster-management.io/v1alpha1
kind: ManagedClusterAddOn
metadata:
  creationTimestamp: '2020-10-15T02:29:53Z'
  generation: 1
  name: observability-controller
  namespace: local-cluster
  resourceVersion: '45273053'
  selfLink: >-
    /apis/addon.open-cluster-management.io/v1alpha1/namespaces/local-cluster/managedclusteraddons/observability-controller
  uid: 8c6ebbd3-e523-4cd7-b448-7d412ca74346
spec: {}
```
