### PR TITLE
get aggregated cluster data instead of names

### DIFF
--- a/src/v2/schema/__snapshots__/topology.test.js.snap
+++ b/src/v2/schema/__snapshots__/topology.test.js.snap
@@ -15,7 +15,10 @@ Object {
           "namespace": "gbapp-gbapp-v2",
           "specs": Object {
             "allChannels": Array [],
-            "allClusters": Array [],
+            "allClusters": Object {
+              "isLocal": false,
+              "remoteCount": 0,
+            },
             "allSubscriptions": Array [],
             "channels": Array [],
             "isDesign": true,

--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -633,6 +633,7 @@ async function getApplicationElements(application, clusterModel) {
   let name;
   let namespace;
   ({ name, namespace } = application);
+  const allAppClusters = application.allClusters ? application.allClusters : [];
   const appId = `application--${name}`;
   nodes.push({
     name,
@@ -646,7 +647,10 @@ async function getApplicationElements(application, clusterModel) {
       activeChannel: application.activeChannel,
       allSubscriptions: application.allSubscriptions ? application.allSubscriptions : [],
       allChannels: application.allChannels ? application.allChannels : [],
-      allClusters: application.allClusters ? application.allClusters : [],
+      allClusters: {
+        isLocal: allAppClusters.indexOf(localClusterName) !== -1,
+        remoteCount: allAppClusters.indexOf('local-cluster') !== -1 ? allAppClusters.length - 1 : allAppClusters.length,
+      },
       channels: application.channels,
     },
   });


### PR DESCRIPTION
**Related Issue:** [closes|resolves|fixes] https://github.com/open-cluster-management/backlog/issues/7733

**Description of Changes**
Return cluster aggregated details instead of the list of cluster names.

- [x] I wrote test cases to cover new code
