### PR TITLE
Handle userAccess query for resources that dont have an apiGroup

### DIFF
--- a/src/v2/models/generic.js
+++ b/src/v2/models/generic.js
@@ -456,7 +456,12 @@ export default class GenericModel extends KubeModel {
   }) {
     let computedResource;
     if (!resource) {
-      computedResource = (await this.getResourceInfo({ apiVersion: apiGroup === '*' ? version : `${apiGroup}/${version}`, kind }))[1].name;
+      computedResource = (await this.getResourceInfo({
+        apiVersion: (apiGroup === '*' || apiGroup === '')
+          ? version
+          : `${apiGroup}/${version}`,
+        kind,
+      }))[1].name;
     }
     const body = {
       apiVersion: authApiVersion,


### PR DESCRIPTION
**Related Issue:** [closes|resolves|fixes] open-cluster-management/backlog#9257

**Description of Changes**
- UserAccess query needs to handle finding the resource type when a resource doesn't have an apigroup. Currently the regex check will error out.
